### PR TITLE
chore: add PR template markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+### Description
+
+Please include a summary of the change, include relevant information and context.
+List any dependencies that are required for this change.
+
+Include a screenshot/GIF of visual UI/UX changes
+
+### Checklist
+
+-   [ ] I have titled my PR in the following format {feat | fix | refactor | chore | docs | revert} {SHORT DESCRIPTION}
+-   [ ] I have add appropriate PR label(s) (self-reviewed, bug fix, code health, update, etc.)
+-   [ ] I have performed a self-review of my own code
+-   [ ] I have commented my code, particularly in hard-to-understand areas
+-   [ ] I did NOT introduce new console warnings
+-   [ ] I have cross-browser tested this feature on both mobile & desktop
+-   [ ] I have added new or updated existing tests pass locally with my changes


### PR DESCRIPTION
### Description
Add PR template and it will automatically add to PR description when opening new PR

### Checklist

-   [x] I have titled my PR in the following format {feat | fix | refactor | chore | docs | revert} {SHORT DESCRIPTION}
-   [x] I have add appropriate PR label(s) (self-reviewed, bug fix, code health, update, etc.)
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I did NOT introduce new console warnings
-   [x] I have cross-browser tested this feature on both mobile & desktop
-   [x] I have added new or updated existing tests pass locally with my changes
